### PR TITLE
Use np.cumsum

### DIFF
--- a/notebooks/Examples.ipynb
+++ b/notebooks/Examples.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mov_avg = [np.mean(results[:r+1]) for r in range(len(results))]"
+    "mov_avg = np.cumsum(results)/(1+np.arange(len(results)))"
    ]
   },
   {


### PR DESCRIPTION
np.cumsum is a "native" NumPy routine that achieves the same result as the list comprehension.

This is not a big deal as this code is not part of the PyEscape library but it provides a cleaner illustration I believe.

PS: I have started to review the JOSS paper for PyEscape