### PR TITLE
Fix possible bugs in passthrough_flat_pore, optimize code

### DIFF
--- a/PyEscape/escape_detection.py
+++ b/PyEscape/escape_detection.py
@@ -1,14 +1,16 @@
 import numpy as np
 
 
-def in_sphere(p, r, p0=np.array([0, 0, 0])):
+def in_sphere(p, r, p0=None):
     """Checks if a particle p is in a sphere with radius r
 
     Optional arguments of p0 is the offset of the container
 
     returns True if p is in p0
     """
-    return np.sum((p-p0)**2) < r**2
+    if p0 is None:
+        return sum(p**2) < r * r
+    return sum((p-p0)**2) < r * r
 
 
 def in_circle(x, y, a=0, b=0, r=25):
@@ -18,7 +20,9 @@ def in_circle(x, y, a=0, b=0, r=25):
 
     returns True if x,y is in circle of position a,b and radius r
     """
-    return (x - a)*(x - a) + (y - b)*(y - b) < r**2
+    x -= a
+    y -= b
+    return x * x + y * y < r * r
 
 
 def in_cube(p, r=1):
@@ -29,7 +33,7 @@ def in_cube(p, r=1):
     returns True if p is in specified cube
     """
     r = r/2
-    return not (np.any(np.logical_or(p <= -r, p >= r)))
+    return not any(np.logical_or(p <= -r, p >= r))
 
 
 def passthrough_pore(p, p0, r=1):
@@ -45,10 +49,9 @@ def passthrough_pore(p, p0, r=1):
 def passthrough_flat_pore(p, p0, r=1):
     """Checks if a point has entered escape zone of a pore,
     flat to the surface of shape
-
     Optional arguments of r size
     """
-    if (p0[2] - r) > p[2] < (p0[2] + r):
+    if -r < p[2] - p0[2] < r:
         return in_circle(p[0], p[1], a=p0[0], b=p0[1], r=r)
     else:
-        False
+        return False


### PR DESCRIPTION
It seems like passthrough_flat_pore is incorrect:
```
def passthrough_flat_pore(p, p0, r=1):
    """Checks if a point has entered escape zone of a pore,
    flat to the surface of shape

    Optional arguments of r size
    """
    if (p0[2] - r) > p[2] < (p0[2] + r):
        return in_circle(p[0], p[1], a=p0[0], b=p0[1], r=r)
    else:
        False
```
The if check is actually testing `(p0[2] - r) > p[2]` (since the other side would be true if this was the case, and if it was not, the test would fail anyways) - this means we don't actually check the bounds. Additionally, False is not returned.

For the optimizations:

np.sum, np.any are equivalent to sum, any for 1 dimensional arrays, but fetching these takes extra time (since Python needs to look up np.sum / np.any) - using the builtins offers a nice speed boost in this case.

Additionally, doing x ** 2 is slower than x * x (since exponentiation has a lot of other things it handles).

I also replaced the default value of p0 with None in in_sphere - this removes a subtraction in most cases, and adds a cheap identity check (is None is very fast), which gives a 20% speed boost when we can skip subtraction, and does not degrade performance otherwise.

I've included timings for simple cases (this is for 10000 iterations) - we can see a speedup of 2x.

Before:
```
in_cube (F) took 0.0631s
in_cube (T) took 0.0615s
in_sphere (F) took 0.0527s
in_sphere (T) took 0.0523s
in_sphere (p0) took 0.0534s
in_circle (F) took 0.0061s
in_circle (T) took 0.0059s
```
After:
```
in_cube (F) took 0.0302s
in_cube (T) took 0.0302s
in_sphere (F) took 0.0230s
in_sphere (T) took 0.0233s
in_sphere (p0) took 0.0280s
in_circle (F) took 0.0029s
in_circle (T) took 0.0029s
```

Testing code:
```
if __name__ == '__main__':
    from timeit import default_timer
    p = np.array([1, 2, 2])
    p0 = np.array([2, 3, 5])
    start = default_timer()
    for i in range(10000):
        in_cube(p, 2)
    end = default_timer()
    print(f"in_cube (F) took {(end - start):.4f}s")
    start = default_timer()
    for i in range(10000):
        in_cube(p, 4)
    end = default_timer()
    print(f"in_cube (T) took {(end - start):.4f}s")
    start = default_timer()
    for i in range(10000):
        in_sphere(p0, 2)
    end = default_timer()
    print(f"in_sphere (F) took {(end - start):.4f}s")
    start = default_timer()
    for i in range(10000):
        in_sphere(p, 2)
    end = default_timer()
    print(f"in_sphere (T) took {(end - start):.4f}s")
    start = default_timer()
    for i in range(10000):
        in_sphere(p, 2, p0)
    end = default_timer()
    print(f"in_sphere (p0) took {(end - start):.4f}s")
    start = default_timer()
    for i in range(10000):
        in_circle(3, 2, r=1)
    end = default_timer()
    print(f"in_circle (F) took {(end - start):.4f}s")
    start = default_timer()
    for i in range(10000):
        in_circle(4, 3, r=5)
    end = default_timer()
    print(f"in_circle (T) took {(end - start):.4f}s")
```